### PR TITLE
Don't remove all events binded on document, just 'checkout_error'

### DIFF
--- a/wirecard-woocommerce-extension/assets/js/creditcard.js
+++ b/wirecard-woocommerce-extension/assets/js/creditcard.js
@@ -345,7 +345,7 @@ jQuery( document ).ajaxComplete(
 				getRequestData( renderForm, logCallback );
 			}
 
-			jQuery( document ).off().on(
+			jQuery( document ).off("checkout_error").on(
 				"checkout_error",
 				"body",
 				function () {

--- a/wirecard-woocommerce-extension/assets/js/creditcard.js
+++ b/wirecard-woocommerce-extension/assets/js/creditcard.js
@@ -345,7 +345,7 @@ jQuery( document ).ajaxComplete(
 				getRequestData( renderForm, logCallback );
 			}
 
-			jQuery( document ).off("checkout_error").on(
+			jQuery( document ).off( "checkout_error" ).on(
 				"checkout_error",
 				"body",
 				function () {

--- a/wirecard-woocommerce-extension/assets/js/sepa.js
+++ b/wirecard-woocommerce-extension/assets/js/sepa.js
@@ -128,7 +128,7 @@ function get_sepa_mandate_data() {
 
 jQuery( document ).ajaxComplete(
 	function() {
-			jQuery( document ).off().on(
+			jQuery( document ).off("checkout_error").on(
 				"checkout_error",
 				"body",
 				function () {

--- a/wirecard-woocommerce-extension/assets/js/sepa.js
+++ b/wirecard-woocommerce-extension/assets/js/sepa.js
@@ -128,7 +128,7 @@ function get_sepa_mandate_data() {
 
 jQuery( document ).ajaxComplete(
 	function() {
-			jQuery( document ).off("checkout_error").on(
+			jQuery( document ).off( "checkout_error" ).on(
 				"checkout_error",
 				"body",
 				function () {


### PR DESCRIPTION
Removing all events binded on "document" will destroy JS functionality in certain WordPress themes. Now it just unbinds the "checkout_error" event.