### PR TITLE
Phraseapp integration (improvements)

### DIFF
--- a/.bin/phraseapp/wd-project.rb
+++ b/.bin/phraseapp/wd-project.rb
@@ -85,8 +85,8 @@ class WdProject
     new_keys_plural = pot_new.map { |h| h[:msgid_plural] }.select { |k| !k.nil? }
     new_keys = (new_keys_singular + new_keys_plural).uniq
 
-    @log.info("Number of keys in the existing POT: #{existing_keys.length}")
-    @log.info("Number of keys in the new POT: #{new_keys.length}")
+    @log.info("Number of keys in the currently existing POT: #{existing_keys.length}")
+    @log.info("Number of keys in the newly generated POT: #{new_keys.length}")
 
     @log.info("Removed keys: #{existing_keys - new_keys}")
     @log.info("Added keys: #{new_keys - existing_keys}")

--- a/.bin/phraseapp/wd-project.rb
+++ b/.bin/phraseapp/wd-project.rb
@@ -76,12 +76,14 @@ class WdProject
   # Compares two POT files and returns true if they have any difference in keys, false otherwise.
   def has_key_changes?
     pot = parse_file(@pot_path)
-    existing_keys = pot.map { |h| h[:msgid] }.select { |k| !k.empty? }.uniq
-    existing_keys += pot.map { |h| h[:msgid_plural] }.select { |k| !k.nil? }.uniq
+    existing_keys_singular = pot.map { |h| h[:msgid] }.select { |k| !k.empty? }
+    existing_keys_plural = pot.map { |h| h[:msgid_plural] }.select { |k| !k.nil? }
+    existing_keys = (existing_keys_singular + existing_keys_plural).uniq
 
     pot_new = parse_file(@pot_new_path)
-    new_keys = pot_new.map { |h| h[:msgid] }.select { |k| !k.empty? }.uniq
-    new_keys += pot_new.map { |h| h[:msgid_plural] }.select { |k| !k.nil? }.uniq
+    new_keys_singular = pot_new.map { |h| h[:msgid] }.select { |k| !k.empty? }
+    new_keys_plural = pot_new.map { |h| h[:msgid_plural] }.select { |k| !k.nil? }
+    new_keys = (new_keys_singular + new_keys_plural).uniq
 
     @log.info("Number of keys in the existing POT: #{existing_keys.length}")
     @log.info("Number of keys in the new POT: #{new_keys.length}")

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = true
 end_of_line = lf
+
+[*.{yml,rb}]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
     after_script: skip
 
   - stage: phraseapp-check-if-in-sync
-    if: type = pull_request
+    if: branch = master OR type = pull_request
     language: ruby
     ruby: 2.5.3
     before_install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,16 +42,26 @@ matrix:
   - <<: *acceptance-test
     env: GATEWAY=NOVA
 
-  - &phraseapp-pull
-    stage: phraseapp-pull
+  - stage: phraseapp-pull
     if: type != cron AND env(PHRASEAPP_PULL) = '1'
     language: ruby
     ruby: 2.5.3
     before_install: skip
     install:
-    - bundle install
+    - travis_retry bundle install
     script:
     - .bin/rake phraseapp:ci_update
+    after_script: skip
+
+  - stage: phraseapp-check-if-in-sync
+    if: type = pull_request
+    language: ruby
+    ruby: 2.5.3
+    before_install: skip
+    install:
+    - travis_retry bundle install
+    script:
+    - .bin/rake phraseapp:ci_check_if_in_sync
     after_script: skip
 
 before_install:


### PR DESCRIPTION
### This PR

* Activates sync checks with PhraseApp on builds for 'master' branch & for pull requests
* Improves key detection function & informational messages
* Extends EditorConfig rules for YAML & Ruby files

### How to test

* Introduce a new key on PhraseApp and tag it with `woocommerce`. Trigger a build on 'master'. The build should not pass because of the keys not being in sync.
* Branch away from this branch and introduce a new translatable key to one of the plugin files. Create a pull request. The pull request should be prevented from merging, until the key is added & tagged on PhraseApp.